### PR TITLE
Fix for CRAB3 zombie jobs

### DIFF
--- a/templates/views/index.html
+++ b/templates/views/index.html
@@ -353,15 +353,19 @@
 
                 for (workflow_key in data) {
                     userTasks = userdata['UserSummary'][workflow_key];
-                    var userTaskHtml = "";
-                    for (var k in userTasks) {
-                        userTaskHtml += k + ": " + userTasks[k] + "<br/>";
+                    if (typeof userTasks === 'undefined') {
+                        console.info('This user ' + workflow_key + ' does not have any ROOT tasks. Out:' + userTasks);
                     }
-                    workflow_data = data[workflow_key];
-                    var image_html = '<img src="'+ currentview +'graphs/' + workflow_key + '"/>';
-                    var workflow_html = '<a href="'+ currentview + workflow_key + '">' + workflow_key + '</a>';
-                    table_data.addRow([workflow_html, workflow_data.Total, workflow_data.Running, workflow_data.Idle, workflow_data.CpusInUse, workflow_data.CpusPending, workflow_data.TaskCount, userTasks.Idle,  workflow_data.SiteCount, image_html, userTaskHtml]);
-                }}
+                    else {
+                        var userTaskHtml = "";
+                        for (var k in userTasks) {
+                            userTaskHtml += k + ": " + userTasks[k] + "<br/>";
+                        }
+                        workflow_data = data[workflow_key];
+                        var image_html = '<img src="'+ currentview +'graphs/' + workflow_key + '"/>';
+                        var workflow_html = '<a href="'+ currentview + workflow_key + '">' + workflow_key + '</a>';
+                        table_data.addRow([workflow_html, workflow_data.Total, workflow_data.Running, workflow_data.Idle, workflow_data.CpusInUse, workflow_data.CpusPending, workflow_data.TaskCount, userTasks.Idle,  workflow_data.SiteCount, image_html, userTaskHtml]);
+                    }}}
             else if (currentview == "/cmsconnectview/" || currentview == "/institutionalview/"){
                 table_data.addColumn("string", "Username");
                 table_data.addColumn("number", "Total");


### PR DESCRIPTION
Seems there are zombie jobs in CRAB3 schedulers. jobs do not have ROOT task and they stay in the queue for a very long time (seems they are all TAIL/PROCESSING jobs from Automatic splitting.)
So for this just secure to make sure to represent information for jobs, which truly have ROOT task. 